### PR TITLE
Add git attributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.c linguist-language="Enforce Script"
+*.st linguist-language="Enfusion String Table"


### PR DESCRIPTION
Display .c files as 'Enforce Script' and .st files as 'Enfusion String Table'

Fixes #112 