### PR TITLE
Fix duplicate IDs in loot item config

### DIFF
--- a/src/Core/Configs/Loot/LootTableConfigDefault.conf
+++ b/src/Core/Configs/Loot/LootTableConfigDefault.conf
@@ -295,7 +295,7 @@ WR_LootTableConfig {
    m_sItemPrefab "{43C4AF1EEBD001CE}Prefabs/Vehicles/Wheeled/UAZ452/UAZ452_ambulance.et"
    m_eCategory SpawnAreaVehicles
   }
-  WR_LootItemConfig "{6323686CF7DE0CB1}" {
+  WR_LootItemConfig "{656A1AE952401555}" {
    m_sItemPrefab "{C7CE8044B5E301F5}Prefabs/Vehicles/Wheeled/UAZ452/UAZ452_transport_CIV_randomized.et"
    m_eCategory SpawnAreaVehicles
   }
@@ -399,8 +399,8 @@ WR_LootTableConfig {
    m_iMinAdditionalItems 5
    m_iMaxAdditionalItems 10
   }
-  WR_LootItemConfig "{6323686CF116429D}" {
-   m_sItemPrefab "{254289B9C09904AB}Prefabs/Vehicles/Wheeled/BRDM2/BRDM2.et"
+  WR_LootItemConfig "{656A1AE91FE7B832}" {
+   m_sItemPrefab "{C012BB3488BEA0C2}Prefabs/Vehicles/Wheeled/BTR70/BTR70.et"
    m_eCategory SpawnAreaVehicles
    m_iWeight 1
    m_aAdditionalItemChoices {
@@ -411,8 +411,8 @@ WR_LootTableConfig {
    m_iMinAdditionalItems 5
    m_iMaxAdditionalItems 10
   }
-  WR_LootItemConfig "{6323686CF12D37B1}" {
-   m_sItemPrefab "{442939C9617DF228}Prefabs/Vehicles/Wheeled/BRDM2/BRDM2_FIA.et"
+  WR_LootItemConfig "{656A1AE8C3F2B0DA}" {
+   m_sItemPrefab "{B47110AA1A806556}Prefabs/Vehicles/Wheeled/BTR70/BTR70_FIA.et"
    m_eCategory SpawnAreaVehicles
    m_iWeight 1
    m_aAdditionalItemChoices {
@@ -423,35 +423,29 @@ WR_LootTableConfig {
    m_iMinAdditionalItems 5
    m_iMaxAdditionalItems 10
   }
-  WR_LootItemConfig "{6323686CF12D37B1}" {
-   m_sItemPrefab "{0FBF8F010F81A4E5}Prefabs/Vehicles/Wheeled/LAV25/LAV25.et"
+  WR_LootItemConfig "{656A1AE8BEC4FEBC}" {
+   m_sItemPrefab "{B47110AA1A806556}Prefabs/Vehicles/Wheeled/BTR70/BTR70_FIA.et"
    m_eCategory SpawnAreaVehicles
    m_iWeight 1
    m_aAdditionalItemChoices {
-    "{8E0429589CD8A49A}Prefabs/Weapons/Magazines/Magazine_M242/Box_25x137_M242_150rnd_HEIT.et"
-    "{06809ADCCDBAB8FB}Prefabs/Weapons/Magazines/Magazine_M242/Box_25x137_M242_60rnd_APDST.et"
-    "{9458584521CCA4E2}Prefabs/Weapons/Magazines/Magazine_M240_Coax/Box_762x51_M240_coax_200rnd_4AP_1Tracer.et"
-    "{96DD0591AFDCC579}Prefabs/Weapons/Magazines/Magazine_M240_Coax/Box_762x51_M240_coax_200rnd_4Ball_1Tracer.et"
-    "{9B34796F40125F85}Prefabs/Weapons/Magazines/Magazine_M240_Coax/Box_762x51_M240_coax_200rnd_Tracer.et"
+    "{8257B5AFDE7AE5CB}Prefabs/Weapons/Magazines/Box_145x114_KPVT_50rnd_4API_1APIT.et"
+    "{D8421F6E70B2FB4F}Prefabs/Weapons/Magazines/Box_762x54_PK_250rnd_4Ball_1Tracer.et"
    }
    m_bAlwaysSpawnAllAdditionalItems 1
-   m_iMinAdditionalItems 4
-   m_iMaxAdditionalItems 8
+   m_iMinAdditionalItems 5
+   m_iMaxAdditionalItems 10
   }
-  WR_LootItemConfig "{6323686CF12D37B1}" {
-   m_sItemPrefab "{B7A8BAA37CB0AC2B}Prefabs/Vehicles/Wheeled/LAV25/LAV25_MERDC.et"
+  WR_LootItemConfig "{656A1AE8BB73F95F}" {
+   m_sItemPrefab "{B47110AA1A806556}Prefabs/Vehicles/Wheeled/BTR70/BTR70_FIA.et"
    m_eCategory SpawnAreaVehicles
    m_iWeight 1
    m_aAdditionalItemChoices {
-    "{8E0429589CD8A49A}Prefabs/Weapons/Magazines/Magazine_M242/Box_25x137_M242_150rnd_HEIT.et"
-    "{06809ADCCDBAB8FB}Prefabs/Weapons/Magazines/Magazine_M242/Box_25x137_M242_60rnd_APDST.et"
-    "{9458584521CCA4E2}Prefabs/Weapons/Magazines/Magazine_M240_Coax/Box_762x51_M240_coax_200rnd_4AP_1Tracer.et"
-    "{96DD0591AFDCC579}Prefabs/Weapons/Magazines/Magazine_M240_Coax/Box_762x51_M240_coax_200rnd_4Ball_1Tracer.et"
-    "{9B34796F40125F85}Prefabs/Weapons/Magazines/Magazine_M240_Coax/Box_762x51_M240_coax_200rnd_Tracer.et"
+    "{8257B5AFDE7AE5CB}Prefabs/Weapons/Magazines/Box_145x114_KPVT_50rnd_4API_1APIT.et"
+    "{D8421F6E70B2FB4F}Prefabs/Weapons/Magazines/Box_762x54_PK_250rnd_4Ball_1Tracer.et"
    }
    m_bAlwaysSpawnAllAdditionalItems 1
-   m_iMinAdditionalItems 4
-   m_iMaxAdditionalItems 8
+   m_iMinAdditionalItems 5
+   m_iMaxAdditionalItems 10
   }
   WR_LootItemConfig "{6323686CF1C58FB5}" {
    m_sItemPrefab "{0B4DEA8078B78A9B}Prefabs/Vehicles/Wheeled/UAZ469/UAZ469_PKM.et"
@@ -594,8 +588,8 @@ WR_LootTableConfig {
    m_iMinAdditionalItems 1
    m_iMaxAdditionalItems 4
   }
-  WR_LootItemConfig "{645AE4DE0B88927D}" {
-   m_sItemPrefab "{443CEFF17E040B11}Prefabs/Weapons/Rifles/VZ58/Rifle_VZ58V.et"
+  WR_LootItemConfig "{656A1AE89E7A663D}" {
+   m_sItemPrefab "{9C948630078D154D}Prefabs/Weapons/Rifles/VZ58/Rifle_VZ58P.et"
    m_eCategory Rifles
    m_aAdditionalItemChoices {
     "{48720FC416263FC1}Prefabs/Weapons/Magazines/Vz58/Magazine_762x39_Vz58_30rnd_Ball.et"
@@ -605,9 +599,8 @@ WR_LootTableConfig {
    m_iMaxAdditionalItems 4
   }
   WR_LootItemConfig "{645AE4DE0B88927D}" {
-   m_sItemPrefab "{9C948630078D154D}Prefabs/Weapons/Rifles/VZ58/Rifle_VZ58P.et"
+   m_sItemPrefab "{443CEFF17E040B11}Prefabs/Weapons/Rifles/VZ58/Rifle_VZ58V.et"
    m_eCategory Rifles
-   m_iWeight 10
    m_aAdditionalItemChoices {
     "{48720FC416263FC1}Prefabs/Weapons/Magazines/Vz58/Magazine_762x39_Vz58_30rnd_Ball.et"
     "{FAFA0D71E75CEBE2}Prefabs/Weapons/Magazines/Vz58/Magazine_762x39_Vz58_30rnd_Tracer.et"

--- a/src/Core/Scripts/Game/Loot/WR_LootItemConfig.c
+++ b/src/Core/Scripts/Game/Loot/WR_LootItemConfig.c
@@ -16,9 +16,9 @@ class WR_LootItemConfig
 	[Attribute("0", desc: "Guarantee that at all additional items will attempt to spawn. Useful for vehicle loadouts.")]
 	bool m_bAlwaysSpawnAllAdditionalItems;
 	
-	[Attribute(defvalue: "0", uiwidget: UIWidgets.Slider, params: "0 10 1")]
+	[Attribute(defvalue: "0", uiwidget: UIWidgets.Slider, params: "0 100 1")]
 	int m_iMinAdditionalItems;
 	
-	[Attribute(defvalue: "0", uiwidget: UIWidgets.Slider, params: "0 10 1")]
+	[Attribute(defvalue: "0", uiwidget: UIWidgets.Slider, params: "0 100 1")]
 	int m_iMaxAdditionalItems;
 }


### PR DESCRIPTION
Remove duplicate WR_LootItemConfig IDs from the default loot table
Increase range of available values for min/max additional items