### PR TITLE
Make transport trucks spawn with supplies

### DIFF
--- a/src/Core/Scripts/Game/Spawning/WR_SpawnAreaVehicleSpawnHandlerComponent.c
+++ b/src/Core/Scripts/Game/Spawning/WR_SpawnAreaVehicleSpawnHandlerComponent.c
@@ -87,7 +87,7 @@ class WR_SpawnAreaVehicleSpawnHandlerComponent : ScriptComponent
 		// Roll chance to spawn with supplies. If successful, fill vehicle with random amount of supplies
 		if (Math.RandomFloat01() <= vehiclesSupplyChance) 
 		{
-			auto supplyStorage = SCR_ResourceComponent.Cast(vehicleEnt.FindComponent(SCR_ResourceComponent));
+			SCR_ResourceComponent supplyStorage = SCR_ResourceComponent.FindResourceComponent(vehicleEnt);
 				
 			if (supplyStorage && supplyStorage.GetContainers())
 			{


### PR DESCRIPTION
Fixed bug preventing transport truck from spawning with supplies by using dedicated `FindResourceComponent` method instead of manually searching for resource component on a vehicle entity.