### PR TITLE
Fix some missions spawning props incorrectly

### DIFF
--- a/src/Arland/Configs/Systems/ChimeraSystemsConfig.conf
+++ b/src/Arland/Configs/Systems/ChimeraSystemsConfig.conf
@@ -2,35 +2,6 @@ SystemSettings : "{45C53F06BA17238D}configs/Systems/SystemsConfig.conf" {
  Systems {
   WR_MissionSystem "{62D4535DAF3772E6}" {
    m_Config WR_MissionSystemConfig "{64D4FDDF69110A3C}" : "{C18AB29E2B867A24}Configs/Missions/WR_MissionSystemConfigArland.conf" {
-    m_aMissionDefinitions {
-     WR_MissionDefinition "{62E77330D3855085}" {
-     }
-     WR_MissionDefinition "{647B3282731F4BCF}" {
-     }
-     WR_MissionDefinition "{62D4535CA29295E4}" {
-     }
-     WR_MissionDefinition "{62E77330DF45097F}" {
-     }
-     WR_MissionDefinition "{62E77330D8EDDE33}" {
-     }
-     WR_MissionDefinition "{62D4535CB0222969}" {
-     }
-     WR_MissionDefinition "{62E77330DBD1B940}" {
-     }
-     WR_MissionDefinition "{62E77330C4E34B8C}" {
-     }
-     WR_MissionDefinition "{62E77330C53B9D26}" {
-     }
-     WR_MissionDefinition "{64755813EE847091}" {
-     }
-     WR_MissionDefinition "{62D4535C9AFBED63}" {
-     }
-     WR_MissionDefinition "{652D2757330E182D}" {
-     }
-    }
-    m_fMissionMapMarkerCleanupDelayM 0.1
-    m_fMissionCleanupDelayM 0.1
-    m_fMissionTimeLimitM 0.2
    }
   }
  }

--- a/src/Arland/Configs/Systems/ChimeraSystemsConfig.conf
+++ b/src/Arland/Configs/Systems/ChimeraSystemsConfig.conf
@@ -1,7 +1,48 @@
 SystemSettings : "{45C53F06BA17238D}configs/Systems/SystemsConfig.conf" {
  Systems {
   WR_MissionSystem "{62D4535DAF3772E6}" {
-   m_Config WR_MissionSystemConfig "{64D4FDDF69110A3C}" : "{C18AB29E2B867A24}Configs/Missions/WR_MissionSystemConfigArland.conf" {
+   m_Config WR_MissionSystemConfig "{64D4FDDF69110A3C}" : "{6604D1D9BACD4790}Configs/Missions/WR_MissionSystemConfigDebug.conf" {
+    m_aMissionDefinitions {
+     WR_MissionDefinition "{62E77330D3855085}" {
+      m_iWeight 0
+     }
+     WR_MissionDefinition "{647B3282731F4BCF}" {
+      m_iWeight 0
+     }
+     WR_MissionDefinition "{62D4535CA29295E4}" {
+      m_iWeight 0
+     }
+     WR_MissionDefinition "{62E77330DF45097F}" {
+      m_iWeight 0
+     }
+     WR_MissionDefinition "{62E77330D8EDDE33}" {
+      m_iWeight 50
+     }
+     WR_MissionDefinition "{62D4535CB0222969}" {
+      m_iWeight 0
+     }
+     WR_MissionDefinition "{62E77330DBD1B940}" {
+      m_iWeight 0
+     }
+     WR_MissionDefinition "{62E77330C4E34B8C}" {
+      m_iWeight 0
+     }
+     WR_MissionDefinition "{62E77330C53B9D26}" {
+      m_iWeight 0
+     }
+     WR_MissionDefinition "{64755813EE847091}" {
+      m_iWeight 0
+     }
+     WR_MissionDefinition "{62D4535C9AFBED63}" {
+      m_iWeight 0
+     }
+     WR_MissionDefinition "{652D2757330E182D}" {
+      m_iWeight 0
+     }
+    }
+    m_fMissionMapMarkerCleanupDelayM 0.1
+    m_fMissionCleanupDelayM 0.1
+    m_fMissionTimeLimitM 0.2
    }
   }
  }

--- a/src/Arland/Configs/Systems/ChimeraSystemsConfig.conf
+++ b/src/Arland/Configs/Systems/ChimeraSystemsConfig.conf
@@ -1,43 +1,31 @@
 SystemSettings : "{45C53F06BA17238D}configs/Systems/SystemsConfig.conf" {
  Systems {
   WR_MissionSystem "{62D4535DAF3772E6}" {
-   m_Config WR_MissionSystemConfig "{64D4FDDF69110A3C}" : "{6604D1D9BACD4790}Configs/Missions/WR_MissionSystemConfigDebug.conf" {
+   m_Config WR_MissionSystemConfig "{64D4FDDF69110A3C}" : "{C18AB29E2B867A24}Configs/Missions/WR_MissionSystemConfigArland.conf" {
     m_aMissionDefinitions {
      WR_MissionDefinition "{62E77330D3855085}" {
-      m_iWeight 0
      }
      WR_MissionDefinition "{647B3282731F4BCF}" {
-      m_iWeight 0
      }
      WR_MissionDefinition "{62D4535CA29295E4}" {
-      m_iWeight 0
      }
      WR_MissionDefinition "{62E77330DF45097F}" {
-      m_iWeight 0
      }
      WR_MissionDefinition "{62E77330D8EDDE33}" {
-      m_iWeight 50
      }
      WR_MissionDefinition "{62D4535CB0222969}" {
-      m_iWeight 0
      }
      WR_MissionDefinition "{62E77330DBD1B940}" {
-      m_iWeight 0
      }
      WR_MissionDefinition "{62E77330C4E34B8C}" {
-      m_iWeight 0
      }
      WR_MissionDefinition "{62E77330C53B9D26}" {
-      m_iWeight 0
      }
      WR_MissionDefinition "{64755813EE847091}" {
-      m_iWeight 0
      }
      WR_MissionDefinition "{62D4535C9AFBED63}" {
-      m_iWeight 0
      }
      WR_MissionDefinition "{652D2757330E182D}" {
-      m_iWeight 0
      }
     }
     m_fMissionMapMarkerCleanupDelayM 0.1

--- a/src/Core/Prefabs/Compositions/Misc/SubCompositions/Tents/WR_Mission_VehicleWreck.et
+++ b/src/Core/Prefabs/Compositions/Misc/SubCompositions/Tents/WR_Mission_VehicleWreck.et
@@ -5,9 +5,13 @@ GenericEntity {
   }
  }
  {
-  GenericEntity : "{B90E5414AB7C325B}Prefabs/Props/Wrecks/BTR70_wreck_static.et" {
-   ID "6546E655999B3DD0"
-   coords 4.503 0 0.015
+  GenericEntity : "{25B265F3E7CBDFC8}Prefabs/Props/Wrecks/BMP1_wreck.et" {
+   ID "656A2E9CAECFCF92"
+   components {
+    Hierarchy "{656A2E9CA94DBD8C}" {
+    }
+   }
+   coords 1.882 0 0.19
   }
   GenericEntity : "{C74EA351062C4CBB}Prefabs/Compositions/Slotted/SlotFlatSmall/SupplyCache_S_FIA_02.et" {
    ID "6546E65478E45D75"

--- a/src/Core/Prefabs/Compositions/Slotted/SlotFlatSmall/WR_Antenna_S_US_01.et
+++ b/src/Core/Prefabs/Compositions/Slotted/SlotFlatSmall/WR_Antenna_S_US_01.et
@@ -35,6 +35,10 @@ GenericEntity : "{6E9190BC2713551D}Prefabs/Compositions/Slotted/BuildableComposi
   }
   GenericEntity : "{76FCF25B67EAB855}Prefabs/Structures/Signs/Military/Supplies/Sign_SupplyStorage_01_Ammo_FIA.et" {
    ID "6546E656CBEC7C47"
+   components {
+    Hierarchy "{656A33659B175CD0}" {
+    }
+   }
    coords 9.075 -0.378 0.811
   }
   GenericEntity : "{7F671B405CDBF0A2}Prefabs/Props/Airport/GeneratorAirfield_US_01/GeneratorAirfield_US_01.et" {

--- a/src/Core/Prefabs/Compositions/Slotted/SlotFlatSmall/WR_MortarMissionProp.et
+++ b/src/Core/Prefabs/Compositions/Slotted/SlotFlatSmall/WR_MortarMissionProp.et
@@ -27,25 +27,45 @@ GenericEntity : "{6E9190BC2713551D}Prefabs/Compositions/Slotted/BuildableComposi
   $grp GenericEntity : "{A3A7C365E845B1B6}PrefabsEditable/Auto/Props/Military/Sandbags/E_Sandbag_01_long_high_burlap.et" {
    {
     ID "652B146E86D00F39"
+    components {
+     Hierarchy "{656A35BA6C1EC275}" {
+     }
+    }
     coords -7.062 0 0.801
     angleY 90
    }
    {
     ID "652B146E88305E52"
+    components {
+     Hierarchy "{656A35BA61F4F0C2}" {
+     }
+    }
     coords 4.912 0 5.778
     angleY 45
    }
    {
     ID "652B146E9C3435DA"
+    components {
+     Hierarchy "{656A35BA66833DE3}" {
+     }
+    }
     coords 0.121 0 7.498
    }
    {
     ID "652B146EAAE06367"
+    components {
+     Hierarchy "{656A35BA6445408A}" {
+     }
+    }
     coords 6.277 0 1.216
     angleY 90
    }
    {
     ID "652B146F724DE827"
+    components {
+     Hierarchy "{656A35BA7F84D015}" {
+     }
+    }
     coords -5.07 0 5.736
     angleY -45
    }

--- a/src/Core/Worlds/WastelandTest/WastelandTest_Layers/default.layer
+++ b/src/Core/Worlds/WastelandTest/WastelandTest_Layers/default.layer
@@ -1,6 +1,24 @@
 WR_GameModeWasteland GameMode_Wasteland1 : "{C4DC8B21CB0B916C}Prefabs/MP/Modes/Wasteland/GameMode_Wasteland.et" {
  coords 124.387 1 142.536
 }
+GenericEntity : "{1141B1DA6D272A70}Prefabs/Compositions/Slotted/SlotFlatSmall/WR_Antenna_S_US_01.et" {
+ coords 104.96 1 154.869
+ {
+  GenericEntity {
+   ID "623F34A149C998C7"
+   {
+    GenericEntity {
+     ID "5CCCBEC480BAEE00"
+     {
+      Turret Tripod_M3_M2HB_656A3365919299B0 {
+       ID "5CB0D9912FD9E690"
+      }
+     }
+    }
+   }
+  }
+ }
+}
 WR_SpawnAreaEntity : "{69FC7C4E0DCB410A}Prefabs/Systems/Spawning/WR_SpawnArea.et" {
  components {
   WR_SpawnAreaBotSpawnHandlerComponent "{652D17722684F2F6}" {


### PR DESCRIPTION
Some prop entities at certain missions did not have hierarchy components, causing them not to snap to the ground properly. This branch adds the necessary hierarchy components.